### PR TITLE
Airflow: Add support for annotations on workers

### DIFF
--- a/charts/airflow-kube-s3/Chart.yaml
+++ b/charts/airflow-kube-s3/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Airflow running with KubernetesExecutor, git-sync and logs to s3
 name: airflow-kube-s3
-version: 0.0.3
+version: 0.0.4
 appVersion: 1.10.9
 icon: https://usr/local/airflow.apache.org/_images/pin_large.png
 home: https://usr/local/airflow.apache.org/

--- a/charts/airflow-kube-s3/templates/cm-config.yaml
+++ b/charts/airflow-kube-s3/templates/cm-config.yaml
@@ -328,6 +328,9 @@ data:
     [kubernetes_annotations]
     # The Key-value annotations pairs to be given to worker pods.
     # Should be supplied in the format: key = value
+    {{- with .Values.airflow.workers.annotations }}
+    {{- toYaml . | trim | nindent 4 }}
+    {{- end }}
 
     [kubernetes_environment_variables]
     # The scheduler sets the following environment variables into your workers. You may define as

--- a/charts/airflow-kube-s3/values.yaml
+++ b/charts/airflow-kube-s3/values.yaml
@@ -202,7 +202,8 @@ airflow:
       AUTH_USER_REGISTRATION = True
       # The default user self registration role
       AUTH_USER_REGISTRATION_ROLE = "User"
-
+  workers:
+    annotations: {}
 ## Ingress configuration
 ingress:
   ## enable ingress


### PR DESCRIPTION
Airflow workers should be able to receive annotations. This will be used to add the annotations necessary to support logging to datadog.

Bumps airflow-kube-s3 to 0.0.4